### PR TITLE
fix(ssh2https): Move from SSH to HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
 		"type-is": "^1.4.0",
 		"webshot": "~0.15.3",
 
-		"node-lib": "git+ssh://git@github.com:Sagacify/node-lib.git#worker",
-		"sg-messaging-server": "git+ssh://git@github.com:Sagacify/sg-messaging-server.git",
-		"sg-files-system": "git+ssh://git@github.com:Sagacify/sg-files-system.git"
+		"node-lib": "git+https://github.com/sagacify/node-lib.git#worker",
+		"sg-messaging-server": "git+https://github.com/sagacify/sg-messaging-server.git",
+		"sg-files-system": "git+https://github.com/sagacify/sg-files-system.git"
 	}
 }


### PR DESCRIPTION
Remove usage of SSH in package.json to avoid SSH key in dockefiles
